### PR TITLE
Server: refactor require auth to use errors and make sure there's only one prisma client instance

### DIFF
--- a/server/controllers/authControllers.js
+++ b/server/controllers/authControllers.js
@@ -5,11 +5,10 @@ import {
     signupSchema,
     flattenError
 } from 'shared/schemas/index.js';
-import { PrismaClient } from '../generated/prisma/client.js';
+import prisma from '../lib/prismaClient.js';
 import { ApplicationError, ValidationError } from '../errors/ErrorClasses.js';
 import { Success } from '../lib/successClasses.js';
 
-const prisma = new PrismaClient();
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 const SALT_ROUNDS = parseInt(process.env.SALT_ROUNDS) || 10;
 

--- a/server/controllers/commentControllers.js
+++ b/server/controllers/commentControllers.js
@@ -1,6 +1,4 @@
-import { PrismaClient } from '../generated/prisma/client.js';
-
-const prisma = new PrismaClient();
+import prisma from '../lib/prismaClient.js';
 
 const getAllComments = async (req, res) => {
     const postId = parseInt(req.params.id);

--- a/server/controllers/plantsControllers.js
+++ b/server/controllers/plantsControllers.js
@@ -1,8 +1,6 @@
-import { PrismaClient } from '../generated/prisma/client.js';
+import prisma from '../lib/prismaClient.js';
 import storage from '../supabase/storageClient.js';
 import { randomUUID } from 'node:crypto';
-
-const prisma = new PrismaClient();
 
 export const getAllPLants = async (req, res) => {
     try {

--- a/server/controllers/postControllers.js
+++ b/server/controllers/postControllers.js
@@ -1,6 +1,4 @@
-import { PrismaClient } from '../generated/prisma/client.js';
-
-const prisma = new PrismaClient();
+import prisma from '../lib/prismaClient.js';
 
 const getPosts = async (req, res) => {
     try {

--- a/server/errors/ErrorClasses.js
+++ b/server/errors/ErrorClasses.js
@@ -28,4 +28,14 @@ class ApplicationError extends Error {
     }
 }
 
-export { ServerError, ValidationError, ApplicationError };
+class AuthenticationError extends Error {
+    constructor(message = '', status = 401) {
+        super();
+        this.message = message;
+        this.errorType = 'AUTHENTICATION_ERROR';
+        this.success = false;
+        this.status = status;
+    }
+}
+
+export { ServerError, ValidationError, ApplicationError, AuthenticationError };

--- a/server/errors/errorHandler.js
+++ b/server/errors/errorHandler.js
@@ -1,7 +1,9 @@
+import jwt from 'jsonwebtoken';
 import {
     ValidationError,
     ServerError,
-    ApplicationError
+    ApplicationError,
+    AuthenticationError
 } from './ErrorClasses.js';
 
 function errorHandler(err, req, res, _next) {
@@ -9,9 +11,17 @@ function errorHandler(err, req, res, _next) {
 
     if (err instanceof ValidationError) res.status(err.status).json(err);
     else if (err instanceof ApplicationError) res.status(err.status).json(err);
-    else {
-        const err = new ServerError();
-        res.status(500).json(err);
+    else if (err instanceof AuthenticationError)
+        res.status(err.status).json(err);
+    else if (
+        err instanceof jwt.TokenExpiredError ||
+        err instanceof jwt.JsonWebTokenError
+    ) {
+        const authenticationError = new AuthenticationError('invalid token');
+        res.status(authenticationError.status).json(authenticationError);
+    } else {
+        const serverError = new ServerError();
+        res.status(500).json(serverError);
     }
 }
 

--- a/server/lib/prismaClient.js
+++ b/server/lib/prismaClient.js
@@ -1,0 +1,5 @@
+import { PrismaClient } from '../generated/prisma/index.js';
+
+const prisma = new PrismaClient();
+
+export default prisma;

--- a/server/middleware/requireAuth.js
+++ b/server/middleware/requireAuth.js
@@ -1,7 +1,6 @@
 import jwt from 'jsonwebtoken';
-import { PrismaClient } from '../generated/prisma/client.js';
+import prisma from '../lib/prismaClient.js';
 
-const prisma = new PrismaClient();
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
 const requireAuth = async (req, res, next) => {

--- a/server/middleware/requireAuth.js
+++ b/server/middleware/requireAuth.js
@@ -1,40 +1,32 @@
 import jwt from 'jsonwebtoken';
 import prisma from '../lib/prismaClient.js';
+import { AuthenticationError } from '../errors/ErrorClasses.js';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
+/**
+ * this middleware will extract and decode the jwt token form authorization header, query the database for user
+ * and attach the user object to request. Will throw error if token is invalid or user is not found
+ */
 const requireAuth = async (req, res, next) => {
     const authHeader = req.headers.authorization;
 
-    if (!authHeader?.startsWith('Bearer')) {
-        return res
-            .status(401)
-            .json({ success: false, message: 'Unauthorized' });
-    }
+    if (!authHeader?.startsWith('Bearer'))
+        throw new AuthenticationError('Invalid Authorization header schema');
 
     const token = authHeader.split(' ')[1];
 
-    try {
-        const decoded = jwt.verify(token, JWT_SECRET);
+    //will throw error if token is invalid or expired which will be caught by errorHandler
+    const decoded = jwt.verify(token, JWT_SECRET);
 
-        const user = await prisma.user.findUnique({
-            where: { username: decoded.username }
-        });
+    const user = await prisma.user.findUnique({
+        where: { username: decoded.username }
+    });
 
-        if (!user) {
-            return res
-                .status(401)
-                .json({ success: false, message: 'Invalid token' });
-        }
+    if (!user) throw new AuthenticationError('User not found');
 
-        req.user = user;
-        next();
-    } catch (error) {
-        console.log(error);
-        return res
-            .status(401)
-            .json({ success: false, message: 'Token invalid' });
-    }
+    req.user = user;
+    next();
 };
 
 export default requireAuth;

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -1,6 +1,4 @@
-import { PrismaClient } from '../generated/prisma/client.js';
-
-const prisma = new PrismaClient();
+import prisma from '../lib/prismaClient.js';
 
 async function seed() {
   // Seed a user


### PR DESCRIPTION
## Pull Request Requirments
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checked otherwise they will stay unchecked. -->

-   [ ] There is a corrsponding issue for this PR and it is assigned to me.


## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Refactoring requireAuth to use global error handling makes it leaner and easier to understand.
## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- requireAuth middleware now throws using error classes and thus global errorHandler handles them all
- prisma client only has one instance active now so now database connections can't be exhausted

## Screenshots (visual changes in client side)
<!-- if this pr changes how the website looks please include screenshots of the changes. The changes can be
adding a new component/page or visual changes in an existing component, you do not need to include screenshots of the whole site
just the changes -->

## Issue
<!--If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013. -->

Closes #XXXXX
